### PR TITLE
Delete '$' from 'print'

### DIFF
--- a/Python/main.py
+++ b/Python/main.py
@@ -45,7 +45,7 @@ class Handler(FileSystemEventHandler):
 
     def on_modified(self, event):  # 파일, 디렉터리가 수정되면 실행
         if "BOJ" not in event.src_path:
-            print(f'파일 이름에 BOJ이 포함되지 않습니다. (현재 파일명 : ${event.src_path})')
+            print(f'파일 이름에 BOJ이 포함되지 않습니다. (현재 파일명 : {event.src_path})')
             return
 
         if self.last_src == event.src_path:
@@ -56,11 +56,11 @@ class Handler(FileSystemEventHandler):
         problemNum = event.src_path[7:-4]
 
         if not 4 <= len(problemNum) <= 5:
-            print(f'${problemNum} 파일명을 확인해주세요.')
+            print(f'{problemNum} 파일명을 확인해주세요.')
             return
 
         if not self.file.checkproblem(problemNum):
-            print(f'${problemNum}이 이미 저장한 목록에 추가되어 있습니다.')
+            print(f'{problemNum}이 이미 저장한 목록에 추가되어 있습니다.')
             return
 
         sourcecode = self.file.getsourcecode(event.src_path)


### PR DESCRIPTION
This will delete unnecessary characters from 'print'.

Signed-off-by: Seojeonguk <uk7880@naver.com>